### PR TITLE
Builder view main

### DIFF
--- a/.settings/org.eclipse.buildship.core.prefs
+++ b/.settings/org.eclipse.buildship.core.prefs
@@ -1,3 +1,6 @@
+GRADLE_BUILD_COMMANDS=org.eclipse.jdt.core.javabuilder
+GRADLE_FILTERS=1.0-projectRelativePath-matches-false-false-build,1.0-projectRelativePath-matches-false-false-.gradle
+GRADLE_NATURES=org.eclipse.jdt.core.javanature
 build.commands=org.eclipse.jdt.core.javabuilder
 connection.arguments=
 connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)

--- a/src/main/java/menelaus/builderview/BuilderMainView.java
+++ b/src/main/java/menelaus/builderview/BuilderMainView.java
@@ -1,0 +1,146 @@
+package menelaus.builderview;
+
+import java.awt.BorderLayout;
+import java.awt.EventQueue;
+
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.border.EmptyBorder;
+import javax.swing.GroupLayout;
+import javax.swing.GroupLayout.Alignment;
+import javax.swing.JLabel;
+import javax.swing.JTextField;
+import javax.swing.LayoutStyle.ComponentPlacement;
+import javax.swing.JSplitPane;
+import javax.swing.JButton;
+import java.awt.event.ActionListener;
+import java.awt.event.ActionEvent;
+import javax.swing.JSpinner;
+import javax.swing.SpinnerNumberModel;
+
+public class BuilderMainView extends JFrame {
+	private JTextField txtLevelName;
+
+	/**
+	 * Launch the application.
+	 */
+	public static void main(String[] args) {
+		EventQueue.invokeLater(new Runnable() {
+			public void run() {
+				try {
+					BuilderMainView frame = new BuilderMainView();
+					frame.setVisible(true);
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+	}
+
+	/**
+	 * Create the frame.
+	 */
+	public BuilderMainView() {
+		setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+		setBounds(100, 100, 799, 604);
+		
+		JLabel lblName = new JLabel("Name: ");
+		lblName.setBounds(251, 14, 34, 14);
+		
+		txtLevelName = new JTextField();
+		txtLevelName.setBounds(295, 11, 131, 20);
+		txtLevelName.setColumns(10);
+		
+		JPanel panelBoardView = new JPanel();
+		panelBoardView.setBounds(363, 105, 410, 449);
+		
+		JPanel panelAllPiecesView = new JPanel();
+		panelAllPiecesView.setBounds(6, 105, 233, 449);
+		
+		JPanel panelBullpenView = new JPanel();
+		panelBullpenView.setBounds(251, 105, 108, 449);
+		
+		JLabel lblBullpen = new JLabel("Bullpen");
+		lblBullpen.setBounds(289, 80, 34, 14);
+		
+		JLabel lblAllPieces = new JLabel("All Pieces");
+		lblAllPieces.setBounds(100, 80, 44, 14);
+		getContentPane().setLayout(null);
+		getContentPane().add(panelAllPiecesView);
+		getContentPane().add(panelBullpenView);
+		getContentPane().add(txtLevelName);
+		getContentPane().add(lblName);
+		getContentPane().add(panelBoardView);
+		getContentPane().add(lblAllPieces);
+		getContentPane().add(lblBullpen);
+		
+		JButton btnReset = new JButton("Reset");
+		btnReset.setBounds(363, 38, 61, 23);
+		getContentPane().add(btnReset);
+		
+		JButton btnDone = new JButton("Done");
+		btnDone.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent arg0) {
+			}
+		});
+		btnDone.setBounds(434, 38, 61, 23);
+		getContentPane().add(btnDone);
+		
+		JButton btnUndo = new JButton("Undo");
+		btnUndo.addActionListener(new ActionListener() {
+			public void actionPerformed(ActionEvent e) {
+			}
+		});
+		btnUndo.setBounds(505, 38, 61, 23);
+		getContentPane().add(btnUndo);
+		
+		JButton btnRedo = new JButton("Redo");
+		btnRedo.setBounds(576, 38, 61, 23);
+		getContentPane().add(btnRedo);
+		
+		JButton btnMakePiece = new JButton("Make Piece");
+		btnMakePiece.setBounds(479, 72, 108, 23);
+		getContentPane().add(btnMakePiece);
+		
+		JButton btnMakeHint = new JButton("Make Hint");
+		btnMakeHint.setBounds(597, 72, 108, 23);
+		getContentPane().add(btnMakeHint);
+		
+		JButton btnExit = new JButton("Exit");
+		btnExit.setBounds(644, 38, 61, 23);
+		getContentPane().add(btnExit);
+		
+		JLabel lblMaximum = new JLabel("Maximum Moves");
+		lblMaximum.setBounds(489, 14, 91, 14);
+		getContentPane().add(lblMaximum);
+		
+		JSpinner spinnerMax = new JSpinner();
+		spinnerMax.setModel(new SpinnerNumberModel(new Integer(0), null, null, new Integer(1)));
+		spinnerMax.setBounds(590, 11, 44, 20);
+		getContentPane().add(spinnerMax);
+		
+		JSpinner spinnerMax2 = new JSpinner();
+		spinnerMax2.setBounds(644, 11, 44, 20);
+		getContentPane().add(spinnerMax2);
+		
+		JLabel lblMaxMiddle = new JLabel(":");
+		lblMaxMiddle.setBounds(637, 14, 7, 14);
+		getContentPane().add(lblMaxMiddle);
+		
+		JButton btnSelectAll = new JButton("Select All");
+		btnSelectAll.setBounds(6, 76, 89, 23);
+		getContentPane().add(btnSelectAll);
+		
+		JButton btnDeselectAll = new JButton("Deselect All");
+		btnDeselectAll.setBounds(150, 76, 89, 23);
+		getContentPane().add(btnDeselectAll);
+		
+		JPanel panelPuzzleNums = new JPanel();
+		panelPuzzleNums.setBounds(6, 11, 233, 62);
+		getContentPane().add(panelPuzzleNums);
+		
+		JButton btnRandoms = new JButton("Random #s");
+		btnRandoms.setBounds(363, 72, 108, 23);
+		getContentPane().add(btnRandoms);
+	}
+}


### PR DESCRIPTION
Just the main UI for the builder. Includes all buttons for lightning, puzzle, or release, with the intent that this class will then be subclassed for each type of level. Each subclass, in its constructor, will hide what it doesn't need. This way, in order to change the layout of all three, only a single class must be changed. This is convenient because most likely, changes to the layout of the interface will not be on a per-level-type basis.

Uses a few panels for the board, bullpen, numbers in release, and all piece bullpen. These will contain bullpen views, board views, etc.